### PR TITLE
chore: ignore gradle-related vulns (build-time only)

### DIFF
--- a/.github/dependency-review.yml
+++ b/.github/dependency-review.yml
@@ -4,4 +4,15 @@ retry-on-snapshot-warnings: true
 comment-summary-in-pr: always
 vulnerability-check: true
 license-check: true
-allow-ghsas: []
+allow-ghsas:
+- GHSA-735f-pc8j-v9w8
+- GHSA-xq3w-v528-46rv
+- GHSA-4265-ccf5-phj5
+- GHSA-4g9r-vxhx-9pgx
+- GHSA-4h8f-2wvx-gg5w
+- GHSA-8xfc-gm6g-vgpv
+- GHSA-m44j-cfrm-g8qc
+- GHSA-v435-xc8x-wvr9
+- GHSA-3p86-9955-h393
+- GHSA-5mg8-w23w-74h3
+- GHSA-7g45-4rm6-3mm3

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,46 @@
+# Gradle dependencies which are ignored because they do not pass on these vulnerabilities
+# transitively to outputs themselves.
+
+[[IgnoredVulns]]
+id = "GHSA-735f-pc8j-v9w8"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-xq3w-v528-46rv"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-4265-ccf5-phj5"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-4g9r-vxhx-9pgx"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-4h8f-2wvx-gg5w"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-8xfc-gm6g-vgpv"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-m44j-cfrm-g8qc"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-v435-xc8x-wvr9"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-3p86-9955-h393"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-5mg8-w23w-74h3"
+reason = "Build-time dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-7g45-4rm6-3mm3"
+reason = "Build-time dependency"


### PR DESCRIPTION
Reviews vulnerabilities reported by the OSV scanner, and suppresses all of them, because every single one (so far) is related to Gradle's dependencies, which we do not pass on to our users.

After a thorough check of each GHSA, I have suppressed it here for both OSV and Dependency Review.