### PR TITLE
fix: don't report gradle's deps as our own

### DIFF
--- a/.github/workflows/job.dependency-graph.yml
+++ b/.github/workflows/job.dependency-graph.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+env:
+  DEPENDENCY_GRAPH_INCLUDE_PROJECTS: 'commons,config,protocol,sdk'
+  DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: 'compileClasspath,runtimeClasspath'
+
 jobs:
   dependency-submission:
     name: "Dependency Graph"
@@ -37,3 +41,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Submit: Dependency Graph"
         uses: gradle/actions/dependency-submission@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
+      - name: "Artifact: Dependency Graph"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: dependency-graph.json
+          path: ./dependency-graph-reports/pr-dependency-submission.json
+          retention-days: 5
+          if-no-files-found: warn

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -108,7 +108,7 @@ jobs:
     with:
       upload-sarif: false
       fail-on-vuln: false
-      scan-args: --config=./.dev/osv.toml --call-analysis=all --lockfile=pnpm-lock.yaml --lockfile=Cargo.lock --lockfile=*/gradle.lockfile
+      scan-args: --config=./.dev/osv.toml --call-analysis=all .
 
   check-depreview:
     name: "Check"

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -39,6 +39,7 @@
          <ignored-key id="F6D4A1D411E9D1AE" reason="Key couldn't be downloaded from any key server"/>
       </ignored-keys>
       <trusted-keys>
+         <trusted-key id="7B79ADD11F8A779FE90FD3D0893A028475557671" group="org.gradle" name="github-dependency-graph-gradle-plugin"/>
          <trusted-key id="015479E1055341431B4545AB72475FD306B9CAB7" group="com.googlecode.javaewah" name="JavaEWAH" version="1.1.12"/>
          <trusted-key id="03C123038C20AAE9E286C857479D601F3A7B5C1A">
             <trusting group="com.github.ajalt.clikt"/>


### PR DESCRIPTION
Reports `runtimeClasspath` and `compileClasspath` configurations to the GitHub Dependency Graph API, instead of all of them. We can't control Gradle's own dependency graph, and it isn't passed on to our users, so it doesn't make sense to address vulnerabilities there like we do in transitive dependencies.